### PR TITLE
Added eth_get_transaction_by_hash function

### DIFF
--- a/infura/infura.py
+++ b/infura/infura.py
@@ -107,3 +107,11 @@ class Client():
         r = self.__req()
 
         return r['result']
+    
+    def eth_get_transaction_by_hash(self, transaction_hash):
+        self._payload['method'] = 'eth_getTransactionByHash'
+        self._params = [transaction_hash]
+
+        r = self.__req()
+
+        return r['result']


### PR DESCRIPTION
Example of usage (see main documentation first):
`ifr.eth_get_transaction_by_hash('0xd4e2258388bd1cd4aef073860f883d8e392f9b0e199f0bdeb97eec862bbac909')`

Reference = https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash